### PR TITLE
fix compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 sift_bam_max_cov: sift_bam_max_cov.cpp
-	g++ sift_bam_max_cov.cpp -Wall -lhts -O2 -I../htslib -L../htslib -o bamsifter
+	g++ -std=c++11 sift_bam_max_cov.cpp -Wall -lhts -O2 -I../htslib -L../htslib -o bamsifter


### PR DESCRIPTION
bamsifter compilation fails on (at least) Ubuntu 18.04 LTS unless -std=c++11 is specified.

```
g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
```

Shortened output:

```
sift_bam_max_cov.cpp: In function ‘void insert_or_increment(std::map<int, int>&, int32_t)’:
sift_bam_max_cov.cpp:28:5: warning: ‘auto’ changes meaning in C++11; please remove it [-Wc++0x-compat]
     auto it = pos_map.find(rpos);
     ^
sift_bam_max_cov.cpp:28:10: error: ‘it’ does not name a type
     auto it = pos_map.find(rpos);
          ^
sift_bam_max_cov.cpp:29:9: error: ‘it’ was not declared in this scope
     if (it != pos_map.end()) {
         ^
sift_bam_max_cov.cpp:33:24: warning: extended initializer lists only available with -std=c++11 or -std=gnu++11
         pos_map.insert({rpos, 1});
                        ^
sift_bam_max_cov.cpp:33:33: warning: extended initializer lists only available with -std=c++11 or -std=gnu++11
         pos_map.insert({rpos, 1});
```