### PR TITLE
<string> for std::string rather than <string.h> in c++

### DIFF
--- a/sift_bam_max_cov.cpp
+++ b/sift_bam_max_cov.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 // #include <unistd.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
 #include <getopt.h>
 #include <stdint.h>
 #include <limits.h>


### PR DESCRIPTION
A compile error was encountered with gcc-10.2
The message was below and the error disappeared after changing <string.h> to <string>.

make[2]: Entering directory '/home/tomoaki/trinityrnaseq-v2.12.0/trinity-plugins/bamsifter'
g++ -std=c++11 -o _sift_bam_max_cov sift_bam_max_cov.cpp -Wall -O2 -L./htslib/build/lib/ -I./htslib/build/include -lhts
sift_bam_max_cov.cpp: In function ‘int main(int, char**)’:
sift_bam_max_cov.cpp:145:10: error: ‘string’ is not a member of ‘std’
  145 |     std::string tmp_text(input_header->text, input_header->l_text);
      |          ^~~~~~
sift_bam_max_cov.cpp:16:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string’?
   15 | #include "htslib/bgzf.h"
  +++ |+#include <string>
   16 | 

